### PR TITLE
Account for Unobstructed Area (Timeline Peek)

### DIFF
--- a/src/c/sea-lines.c
+++ b/src/c/sea-lines.c
@@ -110,7 +110,7 @@ static void update_layer(Layer* layer, GContext* ctx) {
     fast_forward_time(now);
   }
 
-  GRect bounds = layer_get_bounds(layer);
+  GRect bounds = layer_get_unobstructed_bounds(layer);
   int vcr = min(bounds.size.h, bounds.size.w) / 2 - PBL_IF_ROUND_ELSE(4, 2);
   GPoint center = grect_center_point(&bounds);
   draw_bg(ctx, bounds, center, vcr);


### PR DESCRIPTION
By using `layer_get_unobstructed_bounds()` instead of `layer_get_bounds()`, the watch face will only draw within the area of the screen that isn't covered by an upcoming Timeline peek. 
<img width="144" height="168" alt="pebble_screenshot_2025-09-11_14-28-24" src="https://github.com/user-attachments/assets/0e2cd9ef-6a18-4e2b-bdbf-525d63e9695c" /> <img width="144" height="168" alt="pebble_screenshot_2025-09-11_14-31-03" src="https://github.com/user-attachments/assets/9810cf5b-9409-4f29-8202-f4e421d3f011" /> <img width="200" height="228" alt="pebble_screenshot_2025-09-11_14-31-27" src="https://github.com/user-attachments/assets/732e4da8-c8ef-4a35-80fb-513e0d0be6f5" />
